### PR TITLE
使测试可用

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
   },
   "dependencies": {
     "axios": "^0.16.1",
+    "babel-polyfill": "^6.23.0",
     "normalize.css": "^6.0.0",
     "vue": "^2.2.6",
     "vue-router": "^2.3.1",

--- a/src/App.vue
+++ b/src/App.vue
@@ -1,6 +1,8 @@
 <template>
   <div id="app">
     <router-view></router-view>
+    <router-link to="/teamIntroduction">团队介绍</router-link>
+    <router-link to="/home">主页</router-link>
   </div>
 </template>
 

--- a/src/views/Home.vue
+++ b/src/views/Home.vue
@@ -1,7 +1,6 @@
 <template>
   <div>
     <h1>主页</h1>
-    <router-link to="/teamIntroduction">团队介绍</router-link>
   </div>
 </template>
 

--- a/src/views/TeamIntroduction.vue
+++ b/src/views/TeamIntroduction.vue
@@ -1,7 +1,6 @@
 <template>
   <div>
     <h1>团队介绍</h1>
-    <router-link to="/home">主页</router-link>
   </div>
 </template>
 

--- a/test/e2e/specs/test.js
+++ b/test/e2e/specs/test.js
@@ -11,9 +11,9 @@ module.exports = {
     browser
       .url(devServer)
       .waitForElementVisible('#app', 5000)
-      .assert.elementPresent('.hello')
-      .assert.containsText('h1', 'Welcome to Your Vue.js App')
-      .assert.elementCount('img', 1)
+      .assert.elementPresent('h1')
+      .assert.containsText('h1', '主页')
+      .assert.elementCount('a', 2)
       .end()
   }
 }

--- a/test/unit/karma.conf.js
+++ b/test/unit/karma.conf.js
@@ -14,7 +14,7 @@ module.exports = function (config) {
     browsers: ['PhantomJS'],
     frameworks: ['mocha', 'sinon-chai', 'phantomjs-shim'],
     reporters: ['spec', 'coverage'],
-    files: ['./index.js'],
+    files: ['../../node_modules/babel-polyfill/dist/polyfill.js', './index.js'],
     preprocessors: {
       './index.js': ['webpack', 'sourcemap']
     },

--- a/test/unit/specs/Hello.spec.js
+++ b/test/unit/specs/Hello.spec.js
@@ -1,11 +1,21 @@
 import Vue from 'vue'
-import Hello from '@/components/Hello'
+import Home from '@/views/Home'
+import TeamIntroduction from '@/views/TeamIntroduction'
 
-describe('Hello.vue', () => {
+describe('Home.vue', () => {
   it('should render correct contents', () => {
-    const Constructor = Vue.extend(Hello)
+    const Constructor = Vue.extend(Home)
     const vm = new Constructor().$mount()
-    expect(vm.$el.querySelector('.hello h1').textContent)
-      .to.equal('Welcome to Your Vue.js App')
+    expect(vm.$el.querySelector('h1').textContent)
+      .to.equal('主页')
+  })
+})
+
+describe('TeamIntroduction.vue', () => {
+  it('should render correct contents', () => {
+    const Constructor = Vue.extend(TeamIntroduction)
+    const vm = new Constructor().$mount()
+    expect(vm.$el.querySelector('h1').textContent)
+      .to.equal('团队介绍')
   })
 })

--- a/yarn.lock
+++ b/yarn.lock
@@ -703,6 +703,14 @@ babel-plugin-transform-strict-mode@^6.24.1:
     babel-runtime "^6.22.0"
     babel-types "^6.24.1"
 
+babel-polyfill@^6.23.0:
+  version "6.23.0"
+  resolved "http://registry.npm.taobao.org/babel-polyfill/download/babel-polyfill-6.23.0.tgz#8364ca62df8eafb830499f699177466c3b03499d"
+  dependencies:
+    babel-runtime "^6.22.0"
+    core-js "^2.4.0"
+    regenerator-runtime "^0.10.0"
+
 babel-preset-env@^1.3.2:
   version "1.4.0"
   resolved "http://registry.npm.taobao.org/babel-preset-env/download/babel-preset-env-1.4.0.tgz#c8e02a3bcc7792f23cded68e0355b9d4c28f0f7a"


### PR DESCRIPTION
- 引入`babel-polyfill`使测试支持`vuex`。
-  修改单元测试和端到端测试的用例使其符合当前demo。